### PR TITLE
Milestone 2 menu UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@vis.gl/react-google-maps": "^1.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-icons": "^5.2.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       },
@@ -14929,6 +14930,14 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
+    },
+    "node_modules/react-icons": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.2.1.tgz",
+      "integrity": "sha512-zdbW5GstTzXaVKvGSyTaBalt7HSfuK5ovrzlpyiWHAFXndXTdd/1hdDHI4xBM1Mn7YriT6aqESucFl9kEXzrdw==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@vis.gl/react-google-maps": "^1.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-icons": "^5.2.1",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/src/App.js
+++ b/src/App.js
@@ -1,38 +1,24 @@
 import './App.css';
-import { APIProvider, Map, AdvancedMarker } from '@vis.gl/react-google-maps';
+import { APIProvider } from '@vis.gl/react-google-maps';
 
+import { TourContextProvider } from './context/TourContext.js';
+import Map from './components/Map.js'
+import MainMenu from './components/MainMenu.js'
 
 function App() {
-  const locations = [
-    { name: "245 Queens Quay W", lat: 43.63774957110286, lng: -79.38722802360513 },
-    { name: "CN Tower", lat: 43.6426, lng: -79.3871 },
-    { name: "Nathan Phillips Square", lat: 43.6527069, lng: -79.3859886 },
-    { name: "Kensington Market", lat: 43.6548336, lng: -79.4131749 },
-    { name: "Eaton Centre", lat: 43.6544382, lng: -79.3832743 },
-  ]
-
   return (
-    <APIProvider apiKey={process.env.REACT_APP_GOOGLE_MAPS_API_KEY}>
-      <Map
-        style={{ width: '100vw', height: '100vh' }}
-        defaultZoom={14}
-        defaultCenter={{ lat: 43.6532, lng: -79.3832 }}
-        defaultTilt={30}
-        onCameraChanged={(ev) =>
-          console.log('camera changed:', ev.detail.center, 'zoom:', ev.detail.zoom)
-        }
-        mapId={process.env.REACT_APP_GOOGLE_MAPS_MAP_ID}
-      >
-        {locations.map((location, index) => (
-          <AdvancedMarker
-            key={index}
-            position={{ lat: location.lat, lng: location.lng }}
-            title={location.name}
-            onClick={() => console.log(`Clicked on ${location.name}`)}
+    <TourContextProvider>
+      <APIProvider apiKey={process.env.REACT_APP_GOOGLE_MAPS_API_KEY}>
+        <div className='relative'>
+          <Map
+            // TODO: Remove coupling here with the w-16 == 4rem which is used to get the width of the map so that the sidebar doesn't obscure it
+            style={{ marginLeft: '4rem', width: 'calc(100vw - 4rem)', height: '100vh' }}
+            mapId={process.env.REACT_APP_GOOGLE_MAPS_MAP_ID}
           />
-        ))}
-      </Map>
-    </APIProvider>
+          <MainMenu />
+        </div>
+      </APIProvider>
+    </TourContextProvider>
   );
 }
 

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -1,9 +1,9 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import App from '../App';
 import { useTourContext } from '../context/TourContext';
 
-jest.mock('../context/TourContext', () => ({
+jest.mock('../context/TourContext.js', () => ({
   TourContextProvider: ({ children }) => <div>{children}</div>,
   useTourContext: jest.fn(),
 }));
@@ -16,6 +16,10 @@ jest.mock('../components/Map.js', () => ({ style }) => (
     <div data-testid="marker">Kensington Market</div>
     <div data-testid="marker">Eaton Centre</div>
   </div>
+));
+
+jest.mock('../components/MainMenu.js', () => () => (
+  <div data-testid="menu">Menu Content</div>
 ));
 
 describe('App', () => {
@@ -47,15 +51,24 @@ describe('App', () => {
       "Eaton Centre"
     ];
 
+    const map = screen.getByTestId('map');
+
     locationNames.forEach((name) => {
-      expect(screen.getByText(name)).toBeInTheDocument();
+      const marker = within(map).getByText(name);
+      expect(marker).toBeInTheDocument();
     });
   });
 
   it('renders TourContextProvider', () => {
     render(<App />);
-    expect(useTourContext).toHaveBeenCalled();
     const locations = useTourContext().locations;
     expect(locations).toEqual(mockLocations);
+  });
+
+  it('renders Menu component', () => {
+    render(<App />);
+    const menu = screen.getByTestId('menu');
+    expect(menu).toBeInTheDocument();
+    expect(menu).toHaveTextContent('Menu Content');
   });
 });

--- a/src/__tests__/App.test.js
+++ b/src/__tests__/App.test.js
@@ -1,33 +1,61 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from '../App';
+import { useTourContext } from '../context/TourContext';
 
-// Mock the @vis.gl/react-google-maps module
-jest.mock('@vis.gl/react-google-maps', () => ({
-  APIProvider: ({ children }) => <div>{children}</div>,
-  Map: ({ children }) => <div>{children}</div>,
-  AdvancedMarker: ({ position, title, onClick }) => (
-    <div data-testid="marker" onClick={onClick}>
-      {title}
-    </div>
-  ),
+jest.mock('../context/TourContext', () => ({
+  TourContextProvider: ({ children }) => <div>{children}</div>,
+  useTourContext: jest.fn(),
 }));
 
-test('renders map with locations', () => {
-  render(<App />);
+jest.mock('../components/Map.js', () => ({ style }) => (
+  <div data-testid="map" style={style}>
+    <div data-testid="marker">245 Queens Quay W</div>
+    <div data-testid="marker">CN Tower</div>
+    <div data-testid="marker">Nathan Phillips Square</div>
+    <div data-testid="marker">Kensington Market</div>
+    <div data-testid="marker">Eaton Centre</div>
+  </div>
+));
 
-  const markers = screen.getAllByTestId('marker');
-  expect(markers).toHaveLength(5);
-
-  const locationNames = [
-    "245 Queens Quay W",
-    "CN Tower",
-    "Nathan Phillips Square",
-    "Kensington Market",
-    "Eaton Centre"
+describe('App', () => {
+  const mockLocations = [
+    { name: '245 Queens Quay W', visiting: true, lat: 43.639, lng: -79.381 },
+    { name: 'CN Tower', visiting: true, lat: 43.6426, lng: -79.3871 },
+    { name: 'Nathan Phillips Square', visiting: true, lat: 43.652, lng: -79.383 },
+    { name: 'Kensington Market', visiting: true, lat: 43.654, lng: -79.402 },
+    { name: 'Eaton Centre', visiting: true, lat: 43.654, lng: -79.380 },
   ];
 
-  locationNames.forEach((name) => {
-    expect(screen.getByText(name)).toBeInTheDocument();
+  beforeEach(() => {
+    useTourContext.mockReturnValue({
+      locations: mockLocations,
+    });
+  });
+
+  it('renders map with locations', () => {
+    render(<App />);
+
+    const markers = screen.getAllByTestId('marker');
+    expect(markers).toHaveLength(5);
+
+    const locationNames = [
+      "245 Queens Quay W",
+      "CN Tower",
+      "Nathan Phillips Square",
+      "Kensington Market",
+      "Eaton Centre"
+    ];
+
+    locationNames.forEach((name) => {
+      expect(screen.getByText(name)).toBeInTheDocument();
+    });
+  });
+
+  it('renders TourContextProvider', () => {
+    render(<App />);
+    expect(useTourContext).toHaveBeenCalled();
+    const locations = useTourContext().locations;
+    expect(locations).toEqual(mockLocations);
   });
 });

--- a/src/__tests__/components/MainMenu.test.js
+++ b/src/__tests__/components/MainMenu.test.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { useTourContext } from '../../context/TourContext';
+import MainMenu from '../../components/MainMenu';
+
+jest.mock('../../context/TourContext');
+jest.mock('../../components/ui/Sidebar', () => ({ expandedContent }) => <div>{expandedContent}</div>);
+jest.mock('../../components/ui/Checklist', () => ({ options, onChange }) => (
+  <div>
+    {options.map((option) => (
+      <div key={option.id}>
+        <input
+          data-testid={option.label}
+          type="checkbox"
+          checked={option.checked}
+          disabled={option.disabled}
+          onChange={() => {
+            const updatedItems = options.map((o) =>
+              o.id === option.id ? { ...o, checked: !o.checked } : o
+            );
+            onChange(updatedItems);
+          }}
+        />
+        <label>{option.label}</label>
+      </div>
+    ))}
+  </div>
+));
+
+const mockLocations = [
+  { name: 'Location 1', visiting: false, required: false },
+  { name: 'Location 2', visiting: true, required: true },
+];
+
+describe('MainMenu', () => {
+  beforeEach(() => {
+    useTourContext.mockReturnValue({
+      locations: mockLocations,
+      setLocations: jest.fn(),
+    });
+  });
+
+  it('renders without crashing', () => {
+    render(<MainMenu />);
+    expect(screen.getByText('TourTo')).toBeInTheDocument();
+    expect(screen.getByText('🌏 Where do you want to visit?')).toBeInTheDocument();
+    expect(screen.getByTestId('Location 1')).toBeInTheDocument();
+    expect(screen.getByTestId('Location 2')).toBeInTheDocument();
+  });
+
+  it('initially sets the checklist options correctly', () => {
+    render(<MainMenu />);
+    const location1Checkbox = screen.getByTestId('Location 1');
+    const location2Checkbox = screen.getByTestId('Location 2');
+    expect(location1Checkbox.checked).toBe(false);
+    expect(location2Checkbox.checked).toBe(true);
+    expect(location2Checkbox.disabled).toBe(true);
+  });
+
+  it('updates the locations when a checklist item is changed', () => {
+    const { setLocations } = useTourContext();
+    render(<MainMenu />);
+    const location1Checkbox = screen.getByTestId('Location 1');
+
+    fireEvent.click(location1Checkbox);
+
+    expect(setLocations).toHaveBeenCalledWith([
+      { name: 'Location 1', visiting: true, required: false },
+      { name: 'Location 2', visiting: true, required: true },
+    ]);
+  });
+
+  it('disables the required locations', () => {
+    render(<MainMenu />);
+    const location2Checkbox = screen.getByTestId('Location 2');
+    expect(location2Checkbox).toBeDisabled();
+  });
+});

--- a/src/__tests__/components/Map.test.js
+++ b/src/__tests__/components/Map.test.js
@@ -1,0 +1,49 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { useTourContext } from '../../context/TourContext';
+import MapWrapper from '../../components/Map';
+
+jest.mock('../../context/TourContext');
+jest.mock('@vis.gl/react-google-maps', () => ({
+  Map: ({ children, defaultZoom, defaultCenter, defaultTilt, mapId, ...props }) => (
+    <div {...props}>{children}</div>
+  ),
+  AdvancedMarker: ({ position, title, onClick }) => (
+    <div data-testid="marker" data-title={title} onClick={onClick}>
+      {title}
+    </div>
+  ),
+}));
+
+const mockLocations = [
+  { name: 'Location 1', visiting: true, lat: 43.6532, lng: -79.3832 },
+  { name: 'Location 2', visiting: false, lat: 43.6510, lng: -79.3800 },
+  { name: 'Location 3', visiting: true, lat: 43.6500, lng: -79.3870 },
+];
+
+describe('MapWrapper', () => {
+  beforeEach(() => {
+    useTourContext.mockReturnValue({
+      locations: mockLocations,
+    });
+  });
+
+  it('renders without crashing', () => {
+    render(<MapWrapper style={{ height: '100vh', width: '100%' }} />);
+    expect(screen.getByTestId('map')).toBeInTheDocument();
+  });
+
+  it('renders markers for visiting locations', () => {
+    render(<MapWrapper style={{ height: '100vh', width: '100%' }} />);
+    const markers = screen.getAllByTestId('marker');
+    expect(markers).toHaveLength(2);
+    expect(markers[0]).toHaveAttribute('data-title', 'Location 1');
+    expect(markers[1]).toHaveAttribute('data-title', 'Location 3');
+  });
+
+  it('does not render markers for non-visiting locations', () => {
+    render(<MapWrapper style={{ height: '100vh', width: '100%' }} />);
+    expect(screen.queryByTestId('Location 2')).toBeNull();
+  });
+
+});

--- a/src/__tests__/components/ui/Checklist.test.js
+++ b/src/__tests__/components/ui/Checklist.test.js
@@ -1,0 +1,61 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+
+import Checklist from '../../../components/ui/Checklist';
+
+describe('Checklist Component', () => {
+  const options = [
+    { id: 1, label: 'Item 1', checked: false, disabled: false },
+    { id: 2, label: 'Item 2', checked: false, disabled: true },
+    { id: 3, label: 'Item 3', checked: true, disabled: false },
+  ];
+
+  test('renders checklist items', () => {
+    render(<Checklist options={options} onChange={() => { }} />);
+
+    options.forEach((item) => {
+      expect(screen.getByText(item.label)).toBeInTheDocument();
+    });
+  });
+
+  test('toggles checkbox on item click', () => {
+    const handleChange = jest.fn();
+    render(<Checklist options={options} onChange={handleChange} />);
+
+    const item1 = screen.getByText('Item 1');
+    fireEvent.click(item1);
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith([
+      { id: 1, label: 'Item 1', checked: true, disabled: false },
+      { id: 2, label: 'Item 2', checked: false, disabled: true },
+      { id: 3, label: 'Item 3', checked: true, disabled: false },
+    ]);
+  });
+
+  test('handles direct checkbox change', () => {
+    const handleChange = jest.fn();
+    render(<Checklist options={options} onChange={handleChange} />);
+
+    const checkbox1 = screen.getByTestId('Item 1');
+    fireEvent.click(checkbox1);
+
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith([
+      { id: 1, label: 'Item 1', checked: true, disabled: false },
+      { id: 2, label: 'Item 2', checked: false, disabled: true },
+      { id: 3, label: 'Item 3', checked: true, disabled: false },
+    ]);
+  });
+
+  test('does not toggle disabled items', () => {
+    const handleChange = jest.fn();
+    render(<Checklist options={options} onChange={handleChange} />);
+
+    const item2 = screen.getByText('Item 2');
+    fireEvent.click(item2);
+
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/components/ui/Sidebar.test.js
+++ b/src/__tests__/components/ui/Sidebar.test.js
@@ -7,23 +7,23 @@ describe('Sidebar Component', () => {
   const expandedContent = <div>Expanded Content</div>;
   const collapsedContent = <div>Collapsed Content</div>;
 
-  test('should render with collapsed state initially', () => {
+  test('should render with expanded state initially', () => {
     render(<Sidebar expandedContent={expandedContent} collapsedContent={collapsedContent} />);
-    
-    expect(screen.getByText('Collapsed Content')).toBeInTheDocument();
+
+    expect(screen.getByText('Expanded Content')).toBeInTheDocument();
     expect(screen.getByRole('button')).toContainHTML('<svg');
-    expect(screen.queryByText('Expanded Content')).not.toBeInTheDocument();
+    expect(screen.queryByText('Collapsed Content')).not.toBeInTheDocument();
   });
 
-  test('should toggle to expanded state on button click', () => {
+  test('should toggle to collapsed state on button click', () => {
     render(<Sidebar expandedContent={expandedContent} collapsedContent={collapsedContent} />);
 
     const toggleButton = screen.getByRole('button');
     fireEvent.click(toggleButton);
 
-    expect(screen.getByText('Expanded Content')).toBeInTheDocument();
+    expect(screen.getByText('Collapsed Content')).toBeInTheDocument();
     expect(screen.getByRole('button')).toContainHTML('<svg');
-    expect(screen.queryByText('Collapsed Content')).not.toBeInTheDocument();
+    expect(screen.queryByText('Expanded Content')).not.toBeInTheDocument();
   });
 
   test('should toggle back to collapsed state on button click again', () => {
@@ -33,7 +33,7 @@ describe('Sidebar Component', () => {
     fireEvent.click(toggleButton);
     fireEvent.click(toggleButton);
 
-    expect(screen.getByText('Collapsed Content')).toBeInTheDocument();
-    expect(screen.queryByText('Expanded Content')).not.toBeInTheDocument();
+    expect(screen.getByText('Expanded Content')).toBeInTheDocument();
+    expect(screen.queryByText('Collapsed Content')).not.toBeInTheDocument();
   });
 });

--- a/src/__tests__/components/ui/Sidebar.test.js
+++ b/src/__tests__/components/ui/Sidebar.test.js
@@ -1,0 +1,39 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import Sidebar from '../../../components/ui/Sidebar';
+
+describe('Sidebar Component', () => {
+  const expandedContent = <div>Expanded Content</div>;
+  const collapsedContent = <div>Collapsed Content</div>;
+
+  test('should render with collapsed state initially', () => {
+    render(<Sidebar expandedContent={expandedContent} collapsedContent={collapsedContent} />);
+    
+    expect(screen.getByText('Collapsed Content')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toContainHTML('<svg');
+    expect(screen.queryByText('Expanded Content')).not.toBeInTheDocument();
+  });
+
+  test('should toggle to expanded state on button click', () => {
+    render(<Sidebar expandedContent={expandedContent} collapsedContent={collapsedContent} />);
+
+    const toggleButton = screen.getByRole('button');
+    fireEvent.click(toggleButton);
+
+    expect(screen.getByText('Expanded Content')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toContainHTML('<svg');
+    expect(screen.queryByText('Collapsed Content')).not.toBeInTheDocument();
+  });
+
+  test('should toggle back to collapsed state on button click again', () => {
+    render(<Sidebar expandedContent={expandedContent} collapsedContent={collapsedContent} />);
+
+    const toggleButton = screen.getByRole('button');
+    fireEvent.click(toggleButton);
+    fireEvent.click(toggleButton);
+
+    expect(screen.getByText('Collapsed Content')).toBeInTheDocument();
+    expect(screen.queryByText('Expanded Content')).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/context/TourContext.test.js
+++ b/src/__tests__/context/TourContext.test.js
@@ -1,0 +1,66 @@
+import React, { act } from 'react';
+import { render, screen } from '@testing-library/react';
+import { TourContextProvider, useTourContext } from '../../context/TourContext';
+
+const TestComponent = () => {
+  const { locations, setLocations } = useTourContext();
+
+  return (
+    <div>
+      <ul>
+        {locations.map((location) => (
+          <li key={location.name}>{location.name}</li>
+        ))}
+      </ul>
+      <button onClick={() => setLocations([{ name: 'New Location', lat: 43.7, lng: -79.4, visiting: false }])}>
+        Update Locations
+      </button>
+    </div>
+  );
+};
+
+describe('TourContext', () => {
+  it('initializes with the correct locations', () => {
+    render(
+      <TourContextProvider>
+        <TestComponent />
+      </TourContextProvider>
+    );
+
+    expect(screen.getByText('245 Queens Quay W')).toBeInTheDocument();
+    expect(screen.getByText('CN Tower')).toBeInTheDocument();
+    expect(screen.getByText('Nathan Phillips Square')).toBeInTheDocument();
+    expect(screen.getByText('Kensington Market')).toBeInTheDocument();
+    expect(screen.getByText('Eaton Centre')).toBeInTheDocument();
+  });
+
+  it('allows updating the locations', () => {
+    render(
+      <TourContextProvider>
+        <TestComponent />
+      </TourContextProvider>
+    );
+
+    const updateButton = screen.getByText('Update Locations');
+    act(() => {
+      updateButton.click();
+    });
+    expect(screen.queryByText('245 Queens Quay W')).toBeNull();
+    expect(screen.getByText('New Location')).toBeInTheDocument();
+  });
+
+  it('throws an error if useTourContext is used outside of TourContextProvider', () => {
+    const ErrorComponent = () => {
+      try {
+        useTourContext();
+      } catch (error) {
+        return <div>{error.message}</div>;
+      }
+      return null;
+    };
+
+    render(<ErrorComponent />);
+
+    expect(screen.getByText('useTourContext must be used within a TourContextProvider')).toBeInTheDocument();
+  });
+});

--- a/src/components/MainMenu.js
+++ b/src/components/MainMenu.js
@@ -1,0 +1,44 @@
+import React, { useState, useEffect } from "react";
+
+import { useTourContext } from '../context/TourContext';
+import Sidebar from "./ui/Sidebar"
+import Checklist from "./ui/Checklist"
+
+const MainMenu = () => {
+  const locationToOption = (location, index) => ({
+    id: index,
+    label: location.name,
+    checked: location.visiting,
+    disabled: location.required,
+  });
+
+  const { locations, setLocations } = useTourContext();
+  const [locationOptions, setLocationOptions] = useState(locations.map(locationToOption));
+
+  useEffect(() => {
+    setLocationOptions(locations.map(locationToOption));
+  }, [locations]);
+
+  const handleChecklistChange = (updatedItems) => {
+    const updatedLocations = locations.map((location, index) => ({
+      ...location,
+      visiting: updatedItems[index].checked,
+    }));
+
+    setLocations(updatedLocations);
+  };
+
+  const expandedContent = (
+    <div>
+      <h1 className="text-xl font-bold mb-4">TourTo</h1>
+      <h2 className="text-l font-bold mb-4">🌏 Where do you want to visit?</h2>
+      <Checklist options={locationOptions} onChange={handleChecklistChange} />
+    </div>
+  );
+
+  return (
+    <Sidebar expandedContent={expandedContent} />
+  )
+}
+
+export default MainMenu;

--- a/src/components/MainMenu.js
+++ b/src/components/MainMenu.js
@@ -32,7 +32,7 @@ const MainMenu = () => {
     <div>
       <h1 className="text-xl font-bold mb-4">TourTo</h1>
       <h2 className="text-l font-bold mb-4">🌏 Where do you want to visit?</h2>
-      <Checklist options={locationOptions} onChange={handleChecklistChange} />
+      <Checklist key={JSON.stringify(locationOptions)} options={locationOptions} onChange={handleChecklistChange} />
     </div>
   );
 

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -15,6 +15,7 @@ const MapWrapper = ({
 
   return (
     <Map
+      data-testid="map"
       style={style}
       defaultZoom={defaultZoom}
       defaultCenter={defaultCenter}

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Map, AdvancedMarker } from '@vis.gl/react-google-maps';
+
+import { useTourContext } from '../context/TourContext';
+
+const MapWrapper = ({
+  style,
+  mapId,
+  defaultZoom = 14,
+  defaultCenter = { lat: 43.6532, lng: -79.3832 },
+  defaultTilt = 30,
+  ...props
+}) => {
+  const { locations } = useTourContext();
+
+  return (
+    <Map
+      style={style}
+      defaultZoom={defaultZoom}
+      defaultCenter={defaultCenter}
+      defaultTilt={defaultTilt}
+      mapId={mapId}
+      {...props}
+    >
+      {locations.filter(l => l.visiting).map((location, index) => (
+        <AdvancedMarker
+          key={index}
+          position={{ lat: location.lat, lng: location.lng }}
+          title={location.name}
+          onClick={() => console.log(`Clicked on ${location.name}`)}
+        />
+      ))}
+    </Map>
+  );
+};
+
+export default MapWrapper;

--- a/src/components/Map.js
+++ b/src/components/Map.js
@@ -7,7 +7,7 @@ const MapWrapper = ({
   style,
   mapId,
   defaultZoom = 14,
-  defaultCenter = { lat: 43.6532, lng: -79.3832 },
+  defaultCenter = { lat: 43.6532, lng: -79.4132 },
   defaultTilt = 30,
   ...props
 }) => {

--- a/src/components/ui/Checklist.js
+++ b/src/components/ui/Checklist.js
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { FaCheck } from 'react-icons/fa';
+
+const Checklist = ({ options, onChange }) => {
+  const [items, setItems] = useState(options);
+
+  const handleCheck = (id) => {
+    const updatedItems = items.map((item) =>
+      item.id === id ? { ...item, checked: !item.checked } : item
+    );
+    setItems(updatedItems);
+    onChange(updatedItems);
+  };
+
+  return (
+    <div className="space-y-2">
+      {items.map((item) => (
+        <div
+          key={item.id}
+          className={`flex items-center p-2 rounded-md border ${
+            item.disabled ? 'bg-gray-200' : 'bg-white'
+          } ${!item.disabled ? 'cursor-pointer hover:bg-gray-50' : ''}`}
+          onClick={!item.disabled ? () => handleCheck(item.id) : null}
+        >
+          <input
+            type="checkbox"
+            className="form-checkbox h-5 w-5 text-blue-600"
+            data-testid={item.label}
+            checked={item.checked}
+            disabled={item.disabled}
+            onChange={() => {}} // event is handled by div, leave this with empty func to prevent console warning 
+          />
+          <span
+            className={`ml-2 text-lg ${
+              item.disabled ? 'text-gray-400' : 'text-gray-900'
+            }`}
+          >
+            {item.label}
+          </span>
+          {item.checked && !item.disabled && (
+            <FaCheck className="ml-auto text-green-500" />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default Checklist;

--- a/src/components/ui/Sidebar.js
+++ b/src/components/ui/Sidebar.js
@@ -1,0 +1,24 @@
+import React, { useState } from 'react';
+import { FaBars, FaTimes } from 'react-icons/fa';
+
+const Sidebar = ({ expandedContent, collapsedContent }) => {
+  const [expanded, setExpanded] = useState(false);
+
+  return (
+    <div className="absolute top-0 flex h-screen shadow-xl">
+      <div className={`relative bg-white text-stone-950 transition-all duration-300 ${expanded ? 'w-96' : 'w-16'}`}>
+        <button
+          className={`absolute top-5 ${expanded ? 'right-5' : 'left-5'} transition-all duration-300`}
+          onClick={() => setExpanded(!expanded)}
+        >
+          {expanded ? <FaTimes size={24} /> : <FaBars size={24} />}
+        </button>
+        <div className={`overflow-hidden ${expanded ? 'p-4' : 'p-2'}`}>
+          {expanded ? expandedContent : collapsedContent}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Sidebar;

--- a/src/components/ui/Sidebar.js
+++ b/src/components/ui/Sidebar.js
@@ -6,6 +6,7 @@ const Sidebar = ({ expandedContent, collapsedContent }) => {
 
   return (
     <div className="absolute top-0 flex h-screen shadow-xl">
+      {/* TODO: Remove coupling here with the w-16 == 4rem which is used to get the width of the map so that the sidebar doesn't obscure it */}
       <div className={`relative bg-white text-stone-950 transition-all duration-300 ${expanded ? 'w-96' : 'w-16'}`}>
         <button
           className={`absolute top-5 ${expanded ? 'right-5' : 'left-5'} transition-all duration-300`}

--- a/src/components/ui/Sidebar.js
+++ b/src/components/ui/Sidebar.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { FaBars, FaTimes } from 'react-icons/fa';
 
 const Sidebar = ({ expandedContent, collapsedContent }) => {
-  const [expanded, setExpanded] = useState(false);
+  const [expanded, setExpanded] = useState(true);
 
   return (
     <div className="absolute top-0 flex h-screen shadow-xl">

--- a/src/context/TourContext.js
+++ b/src/context/TourContext.js
@@ -1,0 +1,39 @@
+import React, { createContext, useContext, useState, useEffect } from 'react';
+
+const _locations = [
+  { name: "245 Queens Quay W", lat: 43.63774957110286, lng: -79.38722802360513, visiting: true, required: true },
+  { name: "CN Tower", lat: 43.6426, lng: -79.3871, visiting: true },
+  { name: "Nathan Phillips Square", lat: 43.6527069, lng: -79.3859886, visiting: true },
+  { name: "Kensington Market", lat: 43.6548336, lng: -79.4131749, visiting: true },
+  { name: "Eaton Centre", lat: 43.6544382, lng: -79.3832743, visiting: true, required: true },
+];
+
+const TourContext = createContext();
+
+export const TourContextProvider = ({ children }) => {
+  const [locations, setLocations] = useState([]);
+
+  useEffect(() => {
+    // Mock initial API call to fetch landmarks from server
+    setLocations(_locations);
+  }, [setLocations]);
+
+  const value = {
+    locations,
+    setLocations,
+  };
+
+  return (
+    <TourContext.Provider value={value}>
+      {children}
+    </TourContext.Provider>
+  );
+};
+
+export const useTourContext = () => {
+  const context = useContext(TourContext);
+  if (context === undefined) {
+    throw new Error('useTourContext must be used within a TourContextProvider');
+  }
+  return context;
+};


### PR DESCRIPTION
### Why
To accomplish Milestone 2, we want to add a menu that allows the user to pick and choose which locations to visit.

### What
- Create sidebar UI component that expands & collapses
- Create checklist component
- Create menu to pick landmarks to visit
  - Used sidebar & checklist component.
  - Created a `TourContext` cross-component state (contains context DS, Provider & hook).
  - Moved Map into a wrapper component so that the TourContext Provider can be in `<App/>`, allowing Map to use the TourContext hook.
- Change default map center (with the menu expanded, make sure all markers are visible by default)

### Test
- Wrote unit tests for:
  - MainMenu
  - Map
  - TourContext
- Modified unit test for:
  - App

- `npm start`

https://github.com/wu-jeffrey/tour-to/assets/38020792/e615fa29-71d4-428f-ad65-8fe9b22cf083

### Other
#### Room for improvement
- Some coupling between map width and menu's collapsed width (ideally changing in one place won't force you to change in the other)
- remove `data-testid` form components (talked abt in wiki, seems like a hack but will leave it for now)
- when unchecking some stuff, there are some blips when the advanced markers disappear. I think it's cause I'm passing an array and filtering. I tried using CSS to hide them instead of un-rendering them, but that didn't work. Might need to think of a better way. Maybe we can have a disabled style instead using the `<Pin/>` component instead. Will try in the next milestone